### PR TITLE
Potential fix for code scanning alert no. 7986: Uncontrolled data used in path expression

### DIFF
--- a/backend/tiuebackend/media_views.py
+++ b/backend/tiuebackend/media_views.py
@@ -22,18 +22,19 @@ class CORSMediaView(View):
             file_path = os.path.join(settings.MEDIA_ROOT, path)
             
             # Безопасно нормализуем путь и проверяем, что файл находится в MEDIA_ROOT
-            media_root_abspath = os.path.abspath(settings.MEDIA_ROOT)
-            file_path_abspath = os.path.abspath(file_path)
-            if not os.path.exists(file_path_abspath) or os.path.commonpath([file_path_abspath, media_root_abspath]) != media_root_abspath:
+            # Use realpath to resolve symlinks for robust security
+            media_root_realpath = os.path.realpath(settings.MEDIA_ROOT)
+            file_path_realpath = os.path.realpath(file_path)
+            if not os.path.exists(file_path_realpath) or os.path.commonpath([file_path_realpath, media_root_realpath]) != media_root_realpath:
                 raise Http404("Файл не найден")
             
             # Определяем MIME тип
-            content_type, _ = mimetypes.guess_type(file_path_abspath)
+            content_type, _ = mimetypes.guess_type(file_path_realpath)
             if not content_type:
                 content_type = 'application/octet-stream'
             
             # Читаем файл
-            with open(file_path_abspath, 'rb') as f:
+            with open(file_path_realpath, 'rb') as f:
                 file_content = f.read()
             
             # Создаем ответ
@@ -49,7 +50,7 @@ class CORSMediaView(View):
             response['Cache-Control'] = 'public, max-age=3600'
             
             # Добавляем content disposition для корректного отображения
-            filename = os.path.basename(file_path_abspath)
+            filename = os.path.basename(file_path_realpath)
             response['Content-Disposition'] = f'inline; filename="{filename}"'
             
             return response


### PR DESCRIPTION
Potential fix for [https://github.com/scrollDynasty/tiueapp/security/code-scanning/7986](https://github.com/scrollDynasty/tiueapp/security/code-scanning/7986)

To robustly address the issue, we should use `os.path.realpath()` instead of `os.path.abspath()` to fully resolve the constructed file path and the media root. `os.path.realpath()` resolves both relative segments and any symbolic links, ensuring the computed path cannot "escape" via symlinks.  
Here’s how to proceed:
- Replace any call to `os.path.abspath()` for both `settings.MEDIA_ROOT` and the constructed file path with `os.path.realpath()`.
- Retain the `os.path.commonpath()` check to ensure the resolved file is within the resolved `MEDIA_ROOT`.
- Document the change (as a code comment) for clarity.
No new imports are required as `os.path.realpath()` is available in the standard library.

The changes are all within the `get` method of `CORSMediaView` in `backend/tiuebackend/media_views.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
