### PR TITLE
Potential fix for code scanning alert no. 7988: Uncontrolled data used in path expression

### DIFF
--- a/backend/tiuebackend/media_views.py
+++ b/backend/tiuebackend/media_views.py
@@ -28,7 +28,8 @@ class CORSMediaView(View):
             media_root_realpath = os.path.realpath(settings.MEDIA_ROOT)
             file_path_realpath = os.path.realpath(file_path)
             # Проверяем, что файл реально находится внутри MEDIA_ROOT
-            if not os.path.exists(file_path_realpath) or os.path.commonpath([file_path_realpath, media_root_realpath]) != media_root_realpath:
+            # Гарантируем, что путь безусловно внутри MEDIA_ROOT с учетом разделителя
+            if not os.path.exists(file_path_realpath) or not file_path_realpath.startswith(media_root_realpath.rstrip(os.sep) + os.sep):
                 raise Http404("Файл не найден")
             
             # Определяем MIME тип


### PR DESCRIPTION
Potential fix for [https://github.com/scrollDynasty/tiueapp/security/code-scanning/7988](https://github.com/scrollDynasty/tiueapp/security/code-scanning/7988)

**General Fix:**  
The best fix is to strictly ensure that the user-provided `path` does not allow escape from the intended root folder (MEDIA_ROOT). This is done by:  
- Normalizing and resolving symlinks with `os.path.realpath` for both the root directory and target file path.  
- Ensuring that the file's resolved path starts with the root's path *plus a separator* (to avoid prefix issues, e.g., `/foo/bar` vs `/foo/barbaz`).
- Optionally, limit problematic characters (optional, but not essential given correct root-path checking).

**Specific Fix:**  
- In line 31, update the check so that the full realpath of the target file must start with the root realpath **plus os.sep**. This guarantees the file is inside the MEDIA_ROOT and not just sharing a common prefix.
- Add a trailing separator to `media_root_realpath` if missing.
- This should be implemented within the `get` method in `CORSMediaView` in `backend/tiuebackend/media_views.py`.
- No additional imports are needed (already imports `os`), and no new methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
