### PR TITLE
Potential fix for code scanning alert no. 7999: Uncontrolled data used in path expression

### DIFF
--- a/backend/tiuebackend/media_views.py
+++ b/backend/tiuebackend/media_views.py
@@ -28,8 +28,11 @@ class CORSMediaView(View):
             media_root_realpath = os.path.realpath(settings.MEDIA_ROOT)
             file_path_realpath = os.path.realpath(file_path)
             # Проверяем, что файл реально находится внутри MEDIA_ROOT
-            # Гарантируем, что путь безусловно внутри MEDIA_ROOT с учетом разделителя
-            if not os.path.exists(file_path_realpath) or not file_path_realpath.startswith(media_root_realpath.rstrip(os.sep) + os.sep):
+            # Используем os.path.commonpath для надежной проверки
+            if (
+                not os.path.exists(file_path_realpath) or
+                os.path.commonpath([file_path_realpath, media_root_realpath]) != media_root_realpath
+            ):
                 raise Http404("Файл не найден")
             
             # Определяем MIME тип


### PR DESCRIPTION
Potential fix for [https://github.com/scrollDynasty/tiueapp/security/code-scanning/7999](https://github.com/scrollDynasty/tiueapp/security/code-scanning/7999)

To safely handle user-controlled file paths, use Python's path-handling utilities to ensure that the final file is strictly located under `MEDIA_ROOT`. The best approach is to normalize, resolve real paths, and then use `os.path.commonpath([resolved_file_path, resolved_media_root]) == resolved_media_root`. This method is robust and immune to prefix-based string tricks or path confusion.  
Edit file `backend/tiuebackend/media_views.py`, replacing the string-based `startswith` check with `os.path.commonpath` comparison, ensuring both paths are fully normalized and real.  
No new imports are needed, as `os.path` is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
