### PR TITLE
Fix app crashing on launch

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,10 +3,8 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: [
-      // Required for expo-router
-      'expo-router/babel',
-      // Reanimated plugin has to be listed last
-      'react-native-reanimated/plugin',
+      // Worklets plugin has to be listed last
+      'react-native-worklets/plugin',
     ],
   };
 };


### PR DESCRIPTION
Fix app crashes by updating Babel plugins to remove deprecated `expo-router/babel` and use `react-native-worklets/plugin`.

The app was crashing due to two deprecated Babel plugins. `expo-router/babel` is no longer needed with Expo SDK 50, and `react-native-reanimated/plugin` has been replaced by `react-native-worklets/plugin`. Updating these resolves the runtime issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-544037f7-539c-4bd1-b7c3-5079e64820a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-544037f7-539c-4bd1-b7c3-5079e64820a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

